### PR TITLE
fix versioning link by removing trailing slash

### DIFF
--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -96,7 +96,7 @@
             <h4>Considerations</h4>
             <ul>
               <li>
-                <a href="/v1/considerations/versioning/">Versioning</a>
+                <a href="/v1/considerations/versioning">Versioning</a>
               </li>
             </ul>
           </div>

--- a/_posts/2013-10-01-considerations-versioning.markdown
+++ b/_posts/2013-10-01-considerations-versioning.markdown
@@ -5,6 +5,7 @@ title: Versioning Considerations
 ---
 
 # Versioning
+
 ## Building for the Future
 Versions are essentially snapshots of a given resource. If things change, we want you to find out immediately. We'd rather an extra HTTP request or 2 than employees receiving incorrect pay.
 


### PR DESCRIPTION
Noticed this page was broken on the live site because of the trailing slash. Weirdly, it works fine locally.