### PR TITLE
Dynamic year throughout doc

### DIFF
--- a/_posts/2013-08-07-employees.markdown
+++ b/_posts/2013-08-07-employees.markdown
@@ -52,7 +52,7 @@ title: Employees
   "department": "Marketing",
   "email": "knight0faith@initech.biz",
   "ssn": "XXX-XX-2940",
-  "date_of_birth": "1813-05-05",
+  "date_of_birth": "1990-05-05",
   "jobs": [
     {
       "id": 1,
@@ -120,7 +120,7 @@ title: Employees
     "department": "Marketing",
     "email": "knight0faith@initech.biz",
     "ssn": "XXX-XX-2940",
-    "date_of_birth": "1813-05-05",
+    "date_of_birth": "1990-05-05",
     "jobs": [
       {
         "id": 1,

--- a/_posts/2013-08-10-pay_periods.markdown
+++ b/_posts/2013-08-10-pay_periods.markdown
@@ -67,5 +67,5 @@ You may provide all, none, or any combination of them to scope the returned data
       => returns all pay periods from the one encompassing January 31, {{ site.time | date: '%Y' }} through the current pay period
 
     GET /v1/companies/3337/pay_periods?start_date={{ site.time | date: '%Y' }}-01-31&end_date={{ site.time | date: '%Y' }}-06-30
-      => returns all pay periods from January 31, {{ site.time | date: '%Y' }} through June 30, {{ site.time | date: '%Y' }}-01-31
+      => returns all pay periods from January 31, {{ site.time | date: '%Y' }} through June 30, {{ site.time | date: '%Y' }}
 

--- a/_posts/2013-08-10-pay_periods.markdown
+++ b/_posts/2013-08-10-pay_periods.markdown
@@ -24,11 +24,11 @@ title: Pay Periods
 ```json
 [
   {
-    "start_date": "2013-02-01",
-    "end_date": "2013-02-15",
+    "start_date": "{{ site.time | date: '%Y' }}-02-01",
+    "end_date": "{{ site.time | date: '%Y' }}-02-15",
     "pay_schedule_id": 7757500908984137,
     "payroll": {
-      "payroll_deadline": "2013-02-18",
+      "payroll_deadline": "{{ site.time | date: '%Y' }}-02-18",
       "processed": true
     },
     "eligible_employees": [
@@ -47,7 +47,7 @@ title: Pay Periods
 
 | Field                     | Description
 | :----------               |:-------------
-| `start_date` & `end_date` | the range of the pay period. So any information you have from February 1, 2013 through February 15, 2013 (inclusive) should be applied to this pay period.
+| `start_date` & `end_date` | the range of the pay period. So any information you have from February 1, {{ site.time | date: '%Y' }} through February 15, {{ site.time | date: '%Y' }} (inclusive) should be applied to this pay period.
 | `payroll`                 | meta information relative to the company's payroll for the requested pay period.
 | `payroll_deadline`        | date by which payroll should be run for employees to be paid on time. This helps you plan in advance for submitting data. For example, if you are tracking time and attendance data, you should submit the cumulative hours for the tracked employees on, and preferably before, this date.
 | `processed`               | whether or not this payroll has been successfully run. If it has, you should consider it 'frozen', as any attempts to update its data will be rejected. Note that passing the `payroll_deadline` does not guarantee that the payroll has been processed; running late payrolls is not uncommon.  Similarly, Gusto users may choose to run payroll before the `payroll_deadline`.
@@ -63,9 +63,9 @@ This endpoint, by default, returns all pay periods for a given company. Companie
 
 You may provide all, none, or any combination of them to scope the returned data. Here are some common use cases:
 
-    GET /v1/companies/3337/pay_periods?start_date=2012-01-31
-      => returns all pay periods from the one encompassing January 31, 2012 through the current pay period
+    GET /v1/companies/3337/pay_periods?start_date={{ site.time | date: '%Y' }}-01-31
+      => returns all pay periods from the one encompassing January 31, {{ site.time | date: '%Y' }} through the current pay period
 
-    GET /v1/companies/3337/pay_periods?start_date=2012-01-31&end_date=2012-06-30
-      => returns all pay periods from January 31, 2012 through June 30, 2012-01-31
+    GET /v1/companies/3337/pay_periods?start_date={{ site.time | date: '%Y' }}-01-31&end_date={{ site.time | date: '%Y' }}-06-30
+      => returns all pay periods from January 31, {{ site.time | date: '%Y' }} through June 30, {{ site.time | date: '%Y' }}-01-31
 

--- a/_posts/2013-08-10-payrolls.markdown
+++ b/_posts/2013-08-10-payrolls.markdown
@@ -21,11 +21,11 @@ layout: sidebar
 [
   {
     "version": "19289df18e6e20f797de4a585ea5a91535c7ddf7",
-    "payroll_deadline": "2013-02-18",
+    "payroll_deadline": "{{ site.time | date: '%Y' }}-02-18",
     "processed": true,
     "pay_period": {
-      "start_date": "2013-02-01",
-      "end_date": "2013-02-15",
+      "start_date": "{{ site.time | date: '%Y' }}-02-01",
+      "end_date": "{{ site.time | date: '%Y' }}-02-15",
       "pay_schedule_id": 7757500908984137
     },
     "totals": {
@@ -179,11 +179,11 @@ You may provide all, none, or any combination of them to scope the returned data
     GET /v1/companies/3337/payrolls?include=benefits,deductions,taxes
       => returns payrolls and includes benefits, deductions, and taxes in employee_compensation. You can choose to include only what you need (/v1/companies/3337/payrolls?include=benefits,taxes)
 
-    GET /v1/companies/3337/payrolls?start_date=2012-01-31
-      => returns all payrolls whose pay period is from the one encompassing January 31, 2012 through the current pay period
+    GET /v1/companies/3337/payrolls?start_date={{ site.time | date: '%Y' }}-01-31
+      => returns all payrolls whose pay period is from the one encompassing January 31, {{ site.time | date: '%Y' }} through the current pay period
 
-    GET /v1/companies/3337/payrolls?start_date=2012-01-31&end_date=2012-06-30
-      => returns all payrolls whose pay period is from January 31, 2012 through June 30, 2012-01-31
+    GET /v1/companies/3337/payrolls?start_date={{ site.time | date: '%Y' }}-01-31&end_date={{ site.time | date: '%Y' }}-06-30
+      => returns all payrolls whose pay period is from January 31, {{ site.time | date: '%Y' }} through June 30, {{ site.time | date: '%Y' }}
 
 ### Update Payroll
 

--- a/_posts/2013-09-30-updating-payrolls-example.markdown
+++ b/_posts/2013-09-30-updating-payrolls-example.markdown
@@ -18,30 +18,30 @@ These examples will assume an <a href="/v1/examples/authentication">authenticate
 
 ### Get Unprocessed Payroll
 
-Let's say we have information for the regular hours of Patricia Churchland from January 01, 2014 through January 20, 2014:
+Let's say we have information for the regular hours of Patricia Churchland from January 01, {{ site.time | date: '%Y' }} through January 20, {{ site.time | date: '%Y' }}:
 
 ```ruby
 work_data = [
-  { date: '2014-01-02', hours: 8 },
-  { date: '2014-01-03', hours: 8 },
-  { date: '2014-01-06', hours: 8 },
-  { date: '2014-01-07', hours: 8 },
-  { date: '2014-01-08', hours: 8 },
-  { date: '2014-01-09', hours: 8 },
-  { date: '2014-01-10', hours: 8 },
-  { date: '2014-01-13', hours: 8 },
-  { date: '2014-01-14', hours: 8 },
-  { date: '2014-01-15', hours: 8 },
-  { date: '2014-01-16', hours: 8 },
-  { date: '2014-01-17', hours: 8 },
-  { date: '2014-01-20', hours: 8 }
+  { date: '{{ site.time | date: "%Y" }}-01-02', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-03', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-06', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-07', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-08', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-09', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-10', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-13', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-14', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-15', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-16', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-17', hours: 8 },
+  { date: '{{ site.time | date: "%Y" }}-01-20', hours: 8 }
 ]
 ```
 
  First we'll request the unprocessed payrolls for that time-period:
 
 ```
-  GET https://api.gusto.com/v1/companies/94158/payrolls?processed=false&start_date=2014-01-01&end_date=2014-01-20
+  GET https://api.gusto.com/v1/companies/94158/payrolls?processed=false&start_date={{ site.time | date: '%Y' }}-01-01&end_date={{ site.time | date: '%Y' }}-01-20
 ```
 
 After deserializing the JSON response, we'll have an array of payroll objects:
@@ -50,11 +50,11 @@ After deserializing the JSON response, we'll have an array of payroll objects:
 json_response = [
   {
     "version" => "6a46821b9249c9e30e66f39d61c209a2",
-    "payroll_deadline" => "2014-01-18",
+    "payroll_deadline" => "{{ site.time | date: '%Y' }}-01-18",
     "processed" => false,
     "pay_period" => {
-      "start_date" => "2014-01-01",
-      "end_date" => "2014-01-15",
+      "start_date" => "{{ site.time | date: '%Y' }}-01-01",
+      "end_date" => "{{ site.time | date: '%Y' }}-01-15",
       "pay_schedule_id" => 7757500908984137
     },
     "employee_compensations" => [
@@ -91,11 +91,11 @@ json_response = [
   },
   {
     "version" => "fb38ac6fdebea9646c4ac2e50ad27a21",
-    "payroll_deadline" => "2014-02-03",
+    "payroll_deadline" => "{{ site.time | date: '%Y' }}-02-03",
     "processed" => false,
     "pay_period" => {
-      "start_date" => "2014-01-16",
-      "end_date" => "2014-01-31",
+      "start_date" => "{{ site.time | date: '%Y' }}-01-16",
+      "end_date" => "{{ site.time | date: '%Y' }}-01-31",
       "pay_schedule_id" => 7757500908984137
     },
     "employee_compensations" => [
@@ -246,7 +246,7 @@ If information has changed since your last pull of information from Gusto, you w
 This means that you will need to refetch the payroll data for that pay period and resubmit it. If, for example, the January 16-31 payroll has been updated, we can fetch it with a call to:
 
 ```
-  GET https://api.gusto.com/v1/companies/94158/payrolls?processed=false&start_date=2014-01-16&end_date=2014-01-31
+  GET https://api.gusto.com/v1/companies/94158/payrolls?processed=false&start_date={{ site.time | date: '%Y' }}-01-16&end_date={{ site.time | date: '%Y' }}-01-31
 ```
 
 This should only return that one payroll and we can recompute the data specifically for that pay period. Do not simply copy over the new `version` and resubmit, as you'll likely be overwriting information that the user, an internal Gusto process, or another 3rd party application. This can lead to incorrect pay, miscalculated taxes, and upset users.

--- a/_posts/2014-06-06-compensations.markdown
+++ b/_posts/2014-06-06-compensations.markdown
@@ -47,7 +47,7 @@ a relevant error.
     "rate": "70.00",
     "payment_unit": "Hour",
     "flsa_status": "Nonexempt",
-    "effective_date": "2012-12-11"
+    "effective_date": "{{ site.time | date: '%Y' }}-12-11"
   }
 ]
 ```
@@ -70,7 +70,7 @@ a relevant error.
   "rate": "70.00",
   "payment_unit": "Hour",
   "flsa_status": "Nonexempt",
-  "effective_date": "2012-12-11"
+  "effective_date": "{{ site.time | date: '%Y' }}-12-11"
 }
 ```
 
@@ -108,6 +108,6 @@ a relevant error.
   "rate": "60000.00",
   "payment_unit": "Year",
   "flsa_status": "Exempt",
-  "effective_date": "2014-03-15"
+  "effective_date": "{{ site.time | date: '%Y' }}-03-15"
 }
 ```

--- a/_posts/2014-06-06-jobs.markdown
+++ b/_posts/2014-06-06-jobs.markdown
@@ -50,7 +50,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
       "zip": "94107",
       "country": "USA"
     },
-    "hire_date": "2012-12-11",
+    "hire_date": "{{ site.time | date: '%Y' }}-12-11",
     "title": "Assistant to the Regional Manager",
     "rate": "70.00",
     "payment_unit": "Hour",
@@ -63,7 +63,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
         "rate": "70.00",
         "payment_unit": "Hour",
         "flsa_status": "Nonexempt",
-        "effective_date": "2012-12-11"
+        "effective_date": "{{ site.time | date: '%Y' }}-12-11"
       }
     ]
   },
@@ -81,7 +81,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
       "zip": "94107",
       "country": "USA"
     },
-    "hire_date": "2012-12-11",
+    "hire_date": "{{ site.time | date: '%Y' }}-12-11",
     "title": "Receptionist",
     "rate": "18.00",
     "payment_unit": "Hour",
@@ -94,7 +94,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
         "rate": "45.00",
         "payment_unit": "Hour",
         "flsa_status": "Nonexempt",
-        "effective_date": "2012-12-11"
+        "effective_date": "{{ site.time | date: '%Y' }}-12-11"
       }
     ]
   }
@@ -127,7 +127,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
     "zip": "94107",
     "country": "USA"
   },
-  "hire_date": "2012-12-11",
+  "hire_date": "{{ site.time | date: '%Y' }}-12-11",
   "title": "Assistant to the Regional Manager",
   "rate": "70.00",
   "payment_unit": "Hour",
@@ -140,7 +140,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
       "rate": "70.00",
       "payment_unit": "Hour",
       "flsa_status": "Nonexempt",
-      "effective_date": "2012-12-11"
+      "effective_date": "{{ site.time | date: '%Y' }}-12-11"
     }
   ]
 }
@@ -176,6 +176,6 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
 ```json
 {
   "title": "Assistant to the Regional Manager",
-  "hire_date": "2012-12-21"
+  "hire_date": "{{ site.time | date: '%Y' }}-12-21"
 }
 ```

--- a/_posts/2014-06-10-terminations.markdown
+++ b/_posts/2014-06-10-terminations.markdown
@@ -38,7 +38,7 @@ Note that some states require employees to receive their final wages within 24 h
     "id": 891238902131212,
     "version": "d487dd0b55dfcacdd920ccbdaeafa351",
     "active": true,
-    "effective_date": "2014-03-10",
+    "effective_date": "{{ site.time | date: '%Y' }}-03-10",
     "run_termination_payroll": false
   }
 ]
@@ -59,7 +59,7 @@ Note that some states require employees to receive their final wages within 24 h
   "id": 891238902131212,
   "version": "d487dd0b55dfcacdd920ccbdaeafa351",
   "active": true,
-  "effective_date": "2014-03-10",
+  "effective_date": "{{ site.time | date: '%Y' }}-03-10",
   "run_termination_payroll": false
 }
 ```
@@ -76,7 +76,7 @@ Note that some states require employees to receive their final wages within 24 h
 
 ```json
 {
-  "effective_date": "2014-03-11"
+  "effective_date": "{{ site.time | date: '%Y' }}-03-11"
 }
 ```
 
@@ -92,7 +92,7 @@ Note that some states require employees to receive their final wages within 24 h
 
 ```json
 {
-  "effective_date": "2014-06-30",
+  "effective_date": "{{ site.time | date: '%Y' }}-06-30",
   "run_termination_payroll": true
 }
 ```


### PR DESCRIPTION
This will update the API doc year to year the doc last published.

Test locally:
<img width="799" alt="screen shot 2018-01-26 at 9 00 21 pm" src="https://user-images.githubusercontent.com/138784/35468841-05c84164-02dc-11e8-9b87-f325b0361633.png">
