### PR TITLE
Update HTTP to HTTPS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,18 +4,18 @@
     <meta name="description" content="Gusto (formerly ZenPayroll) API Documentation" />
     <meta property="og:description" content="Gusto (formerly ZenPayroll) API Documentation" />
     <meta property="og:site_name" content="Gusto API" />
-    <meta property="og:image" content="http://docs.gusto.com/images/logos/gusto-horizontal-lockup.png" />
+    <meta property="og:image" content="https://docs.gusto.com/images/logos/gusto-horizontal-lockup.png" />
     <meta property="og:title" content="Gusto API" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" >
 
-    <link rel="apple-touch-icon-precomposed" sizes="57x57" href="http://docs.gusto.com/images/favicons/apple-touch-icon-57x57.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="http://docs.gusto.com/images/favicons/apple-touch-icon-114x114.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="http://docs.gusto.com/images/favicons/apple-touch-icon-72x72.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="http://docs.gusto.com/images/favicons/apple-touch-icon-144x144.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="http://docs.gusto.com/images/favicons/apple-touch-icon-120x120.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="http://docs.gusto.com/images/favicons/apple-touch-icon-152x152.png" />
-    <link rel="icon" type="image/png" href="http://docs.gusto.com/images/favicons/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="http://docs.gusto.com/images/favicons/favicon-16x16.png" sizes="16x16" />
+    <link rel="apple-touch-icon-precomposed" sizes="57x57" href="https://docs.gusto.com/images/favicons/apple-touch-icon-57x57.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://docs.gusto.com/images/favicons/apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://docs.gusto.com/images/favicons/apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://docs.gusto.com/images/favicons/apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="https://docs.gusto.com/images/favicons/apple-touch-icon-120x120.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="https://docs.gusto.com/images/favicons/apple-touch-icon-152x152.png" />
+    <link rel="icon" type="image/png" href="https://docs.gusto.com/images/favicons/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://docs.gusto.com/images/favicons/favicon-16x16.png" sizes="16x16" />
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
          <span class="icon-bar"></span>
          <span class="icon-bar"></span>
        </button>
-       <a class="navbar-brand" href="http://docs.gusto.com">
+       <a class="navbar-brand" href="https://docs.gusto.com">
          <img class="logo" src="https://s3.amazonaws.com/assets.gusto.com/static/images/logos/gusto_docs_logo.svg" alt="Gusto Docs"/>
        </a>
      </div>


### PR DESCRIPTION
FYI: docs.gusto.com previously used HTTP. I upgraded it to use HTTPS. However, this means that I needed to update some of the references to avoid serving mixed content.