### PR TITLE
Doc updates and typo fixes

### DIFF
--- a/_posts/2013-08-10-pay_periods.markdown
+++ b/_posts/2013-08-10-pay_periods.markdown
@@ -33,11 +33,11 @@ title: Pay Periods
     },
     "eligible_employees": [
       {
-        "employee_id": 1123581321345589,
+        "id": 1123581321345589,
         "job_ids": [1]
       },
       {
-        "employee_id": 1442333776109871,
+        "id": 1442333776109871,
         "job_ids": [2]
       }
     ]

--- a/_posts/2013-08-10-payrolls.markdown
+++ b/_posts/2013-08-10-payrolls.markdown
@@ -22,6 +22,7 @@ layout: sidebar
   {
     "version": "19289df18e6e20f797de4a585ea5a91535c7ddf7",
     "payroll_deadline": "{{ site.time | date: '%Y' }}-02-18",
+    "check_date": "{{ site.time | date: '%Y' }}-02-22",
     "processed": true,
     "payroll_id": 7786400908986532,
     "pay_period": {
@@ -152,6 +153,7 @@ layout: sidebar
 | `payroll_id`              | payroll id that can be used to query the specific payroll using get payroll endpoint.
 | `pay_period`              | the start and end date for the pay period corresponding with this payroll.
 | `payroll_deadline`        | deadline for the payroll to be run in order for employees to be paid on-time.
+| `check_date`              | the date at which employees will be paid for this payroll.
 | `processed`               | whether or not this payroll has been successfully run. If it has, you should consider it 'frozen', as any attempts to update its data will be rejected. Note that passing the `payroll_deadline` does not guarantee that the payroll has been processed; running late payrolls is not uncommon.  Similarly, Gusto users may choose to run payroll before the `payroll_deadline`.
 | `totals`                  | subtotals for this payroll
 | `company_debit`           | the total company debit for the payroll
@@ -224,6 +226,7 @@ You may provide all, none, or any combination of them to scope the returned data
 {
   "version": "19289df18e6e20f797de4a585ea5a91535c7ddf7",
   "payroll_deadline": "{{ site.time | date: '%Y' }}-02-18",
+  "check_date": "{{ site.time | date: '%Y' }}-02-22",
   "processed": true,
   "payroll_id": 7786400908986532,
   "pay_period": {
@@ -353,6 +356,7 @@ You may provide all, none, or any combination of them to scope the returned data
 | `payroll_id`              | payroll id that can be used to query the specific payroll using get payroll endpoint.
 | `pay_period`              | the start and end date for the pay period corresponding with this payroll.
 | `payroll_deadline`        | deadline for the payroll to be run in order for employees to be paid on-time.
+| `check_date`              | the date at which employees will be paid for this payroll.
 | `processed`               | whether or not this payroll has been successfully run. If it has, you should consider it 'frozen', as any attempts to update its data will be rejected. Note that passing the `payroll_deadline` does not guarantee that the payroll has been processed; running late payrolls is not uncommon.  Similarly, Gusto users may choose to run payroll before the `payroll_deadline`.
 | `totals`                  | subtotals for this payroll
 | `company_debit`           | the total company debit for the payroll

--- a/_posts/2013-09-30-updating-payrolls-example.markdown
+++ b/_posts/2013-09-30-updating-payrolls-example.markdown
@@ -180,7 +180,7 @@ updated_payroll_data = json_response.map.with_index do |payroll_json, index|
   # Find the 'Regular Hours' hourly compensation
   regular_hours_compensation = churchland_compensation["hourly_compensations"].detect { |hourly_compensation| hourly_compensation["name"] == 'Regular Hours' }
 
-  # Update it to add our ours to the existing ones
+  # Update it to add our hours to the existing ones
   regular_hours_compensation["hours"] = regular_hours_compensation["hours"].to_d + hourly_totals[index]
 
   {

--- a/_posts/2014-06-06-jobs.markdown
+++ b/_posts/2014-06-06-jobs.markdown
@@ -19,6 +19,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
 | `location`                    | Object            |     X     |          |         | full representation of the location's address
 | `hire_date`                   | String            |           |          |         | when the employee was hired for this job
 | `title`                       | String            |           |    X     | null    | the title for this position
+| `primary`                     | Boolean           |     X     |          |         | whether this is the employee's primary job. The value will be set to true unless an existing job exists for this employee.
 | `rate`                        | String            |     X     |          |         | rate for the current compensation
 | `payment_unit`                | String            |     X     |          |         | payment unit for the current compensation
 | `current_compensation_id`     | Integer           |     X     |          |         | id for the currently active compensation
@@ -52,6 +53,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
     },
     "hire_date": "{{ site.time | date: '%Y' }}-12-11",
     "title": "Assistant to the Regional Manager",
+    "primary": true,
     "rate": "70.00",
     "payment_unit": "Hour",
     "current_compensation_id": 1363316536327003,
@@ -83,6 +85,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
     },
     "hire_date": "{{ site.time | date: '%Y' }}-12-11",
     "title": "Receptionist",
+    "primary": true,
     "rate": "18.00",
     "payment_unit": "Hour",
     "current_compensation_id": 1363316536327004,
@@ -129,6 +132,7 @@ Jobs are essentially the intersection of <a href="/v1/employees">an employee</a>
   },
   "hire_date": "{{ site.time | date: '%Y' }}-12-11",
   "title": "Assistant to the Regional Manager",
+  "primary": true,
   "rate": "70.00",
   "payment_unit": "Hour",
   "current_compensation_id": 1363316536327003,


### PR DESCRIPTION
Fix various typos and document missing attributes reported by a partner. 

* Document `primary` on jobs endpoint.
* Document `check_date` on payrolls endpoint.
* Correct `employee_id` to `id` on pay periods endpoint.


