### PR TITLE
Documentation for partner attributes section of Webhooks API

### DIFF
--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -89,6 +89,9 @@
                 <a href="/v1/accounts">Partner Endpoints (Accounts)</a>
               </li>
               <li>
+                <a href="/v1/partner_attributes">Partner Endpoints (Attributes)</a>
+              </li>
+              <li>
                 <a href="/v1/states">Public Endpoints (States)</a>
               </li>
             </ul>

--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -89,9 +89,6 @@
                 <a href="/v1/accounts">Partner Endpoints (Accounts)</a>
               </li>
               <li>
-                <a href="/v1/partner_attributes">Partner Endpoints (Attributes)</a>
-              </li>
-              <li>
                 <a href="/v1/states">Public Endpoints (States)</a>
               </li>
             </ul>

--- a/_posts/2013-08-10-companies.markdown
+++ b/_posts/2013-08-10-companies.markdown
@@ -90,7 +90,7 @@ layout: sidebar
     "first_name": "Isaiah",
     "last_name"  : "Berlin",
     "phone": "8001234567",
-    "email": "crooked-timber@initech.biz",
+    "email": "crooked-timber@initech.biz"
   }
 }
 ```

--- a/_posts/2014-08-01-accounts.markdown
+++ b/_posts/2014-08-01-accounts.markdown
@@ -62,7 +62,7 @@ account creation.
     "states": ["CA", "WA", "TN"]
   },
   "partner": {
-    "name": "Xero",
+    "name": "Carnivora CPA",
     "company_id": "112233445566",
     "user_id": "abcdef1234",
     "accounting_firm_id": "wxyz123456"

--- a/_posts/2018-11-16-webhooks-about.markdown
+++ b/_posts/2018-11-16-webhooks-about.markdown
@@ -40,8 +40,8 @@ The top-level attributes are webhook specific, and an example would look somethi
 ```
 
 In this example, `timestamp`, `event_type`, and `entity_attributes` are all standard keys to have in a webhooks payload.
-In Gusto's system permissions are based on an resource and it's entities. The parent reference is the `resource` while
-the `entity` is the reference to what actually triggered the event.
+Permissions are based on an resource and its entities. The parent reference is the `resource` while the `entity` is the
+reference to what actually triggered the event.
 
 Additionally, any events of type `*.provisioned` may have a `partner_attributes` key. If Gusto has a mapping of that
 entity to an entity in your application, those attributes will contain your identifier to that entity. See the 

--- a/_posts/2018-11-16-webhooks-about.markdown
+++ b/_posts/2018-11-16-webhooks-about.markdown
@@ -40,7 +40,7 @@ The top-level attributes are webhook specific, and an example would look somethi
 ```
 
 In this example, `timestamp`, `event_type`, and `entity_attributes` are all standard keys to have in a webhooks payload.
-Permissions are based on an resource and its entities. The parent reference is the `resource` while the `entity` is the
+Permissions are based on a resource and its entities. The parent reference is the `resource` while the `entity` is the
 reference to what actually triggered the event.
 
 Additionally, any events of type `*.provisioned` may have a `partner_attributes` key. If Gusto has a mapping of that

--- a/_posts/2018-11-16-webhooks-about.markdown
+++ b/_posts/2018-11-16-webhooks-about.markdown
@@ -9,13 +9,20 @@ layout: sidebar
 </h1>
 
 ## About
-Webhooks are a way to get notified when events happen in Gusto so that you do not need to come up with a polling strategy for refreshing data in your app.
+Webhooks are a way to get notified when events happen in Gusto so that you do not need to come up with a polling
+strategy for refreshing data in your app.
 
-Webhooks trigger on certain events and send an HTTP POST payload to the URL that is registered by you for that event. You can limit which events trigger a webhook for your registered URLs.
+Webhooks trigger on certain events and send an HTTP POST payload to the URL that is registered by you for that event.
+You can limit which events trigger a webhook for your registered URLs.
 
-An **event** can be an employee being created for one of your companies, or the company itself being provisioned where access to their events were granted to you. You can create alerts in your app for running payroll based on the pay schedule, and update it if anything changes.
+An **event** can be an employee being created for one of your companies, or the company itself being provisioned where
+access to their events were granted to you. You can create alerts in your app for running payroll based on the pay
+schedule, and update it if anything changes.
 
-A **payload** is the body of the request that will be sent to your app when an event happens. The top-level attributes describe the resources and provide timestamps to compare to other payloads. Every payload has an `entity_attributes` value that is the serialized entity which matches what you would have gotten if you had used our public API to get information on that entity. This way you do not need to query our API every time an event occurs.
+A **payload** is the body of the request that will be sent to your app when an event happens. The top-level attributes
+describe the resources and provide timestamps to compare to other payloads. Every payload has an `entity_attributes`
+value that is the serialized entity which matches what you would have gotten if you had used our public API to get
+information on that entity. This way you do not need to query our API every time an event occurs.
 
 The top-level attributes are webhook specific, and an example would look something like:
 
@@ -27,16 +34,24 @@ The top-level attributes are webhook specific, and an example would look somethi
   "entity_type": "Employee",
   "entity_id": 1123581321345589,
   "timestamp": 1533606328,
-  "entity_attributes": { }
+  "entity_attributes": { },
+  "partner_attributes": { }
 }
 ```
 
-In this example, `timestamp`, `event_type`, and `entity_attributes` are all standard keys to have in a webhooks payload. In Gusto's system permissions are based on an resource and it's entities. The parent reference is the `resource` while the `entity` is the reference to what actually triggered the event.
+In this example, `timestamp`, `event_type`, and `entity_attributes` are all standard keys to have in a webhooks payload.
+In Gusto's system permissions are based on an resource and it's entities. The parent reference is the `resource` while
+the `entity` is the reference to what actually triggered the event.
+
+Additionally, any events of type `*.provisioned` may have a `partner_attributes` key. If Gusto has a mapping of that
+entity to an entity in your application, those attributes will contain your identifier to that entity. See the 
+[Partner Attributes](/v1/partner_attributes) section for more information on its contents.
 
 
 ## Registering
 
-While we are working on adding an API endpoint and eventually a GUI for registering an endpoint with our webhooks system, the current method is to reach out to Gusto to get your webhooks setup with us.
+While we are working on adding an API endpoint and eventually a GUI for registering an endpoint with our webhooks
+system, the current method is to reach out to Gusto to get your webhooks setup with us.
 
 A webhook registration will require the following:
 
@@ -49,11 +64,13 @@ A webhook registration will require the following:
       - [Pay Schedule](/v1/pay_schedules)
       - [Payroll](/v1/payrolls)
 
-After we have setup your registration and subscribed to the desired entities, we will send you a secret token that can be used to verify subsequent notifications sent via the webhook system.
+After we have setup your registration and subscribed to the desired entities, we will send you a secret token that can
+be used to verify subsequent notifications sent via the webhook system.
 
 ## Verification
 
-Each webhook notification will have a header value that includes a signature you can use to verify the notification actually came from Gusto.
+Each webhook notification will have a header value that includes a signature you can use to verify the notification
+actually came from Gusto.
 
 The header signature will look something like this:
 
@@ -69,6 +86,7 @@ same hash from the request body using the verification token we provide when set
 token remains secret, any request with a valid signature will have come from us.
 
 As an example, a rails server consuming this webhook might use the following method:
+
 ```
 before_action :verify_response_origin
 

--- a/_posts/2019-02-27-partner-attributes.markdown
+++ b/_posts/2019-02-27-partner-attributes.markdown
@@ -10,29 +10,23 @@ title: Partner Attributes
 
 | Attribute                     | Type              | Read-Only | Optional | Description
 | :----------                   |:-------------     |:---------:|:--------:|:-------------
-| `company_id`                  | String            |     X     |    X     | unique identifier of this company in your system. (Not to be confused with Gusto's company id)
-| `grants_rev_share`            | Boolean           |     X     |    X     | whether or not you receive revenue shares on behalf of this company
+| `grants_rev_share`            | Boolean           |     X     |    X     | true if you are receiving revenue sharing on behalf of this company
+| `mapping`                     | Object            |     X     |    X     | how the company relates to an entity in your system
+| `mapping:gusto:company_id`    | Integer           |     X     |    X     | unique identifier of this company in our system
+| `mapping:partner:company_id`  | String            |     X     |    X     | unique identifier of this company in your system (optional; partner-dependent)
 
-## Get partner attributes
-
-**HTTP Method**: `GET`
-
-**Endpoint**: `/v1/partner_attributes/:company_id`
-
-**Returns**: Partner-specific information about the company
-
-**Response Codes**:
-
-| Code        | Description
-| :---------- |:------------- 
-| `200`       | ok
-| `404`       | the company was not found or company had no partner details        
-
-#### Sample Response Body:
+#### Sample Body:
 
 ```json
 {
-  "company_id": "food-truck-88913",
-  "grants_rev_share": false
+  "grants_rev_share": false,
+  "mapping": {
+    "partner": {
+      "company_id": "a0c5e109-1a45-40e8-96c9-4fc83f8f08b6"
+    },
+    "gusto": {
+      "company_id": 7389117231658670
+    }
+  }
 }
 ```

--- a/_posts/2019-02-27-partner-attributes.markdown
+++ b/_posts/2019-02-27-partner-attributes.markdown
@@ -12,7 +12,7 @@ title: Partner Attributes
 | :----------                   |:-------------     |:---------:|:--------:|:-------------
 | `company_id`                  | String            |     X     |    X     | unique identifier of this company in your system. (Not to be confused with Gusto's company id)
 | `user_id`                     | String            |     X     |    X     | unique identifier of the company's primary payroll admin in your system.  
-| `grants_rev_share`            | Boolean           |     X     |    X     | 
+| `grants_rev_share`            | Boolean           |     X     |    X     | whether or not you receive revenue shares on behalf of this company
 
 ## Get partner attributes
 
@@ -35,7 +35,6 @@ title: Partner Attributes
 {
   "company_id": "food-truck-88913",
   "user_id": "person-815932",
-  "accounting_firm_id": "firm-3193",
   "grants_rev_share": false
 }
 ```

--- a/_posts/2019-02-27-partner-attributes.markdown
+++ b/_posts/2019-02-27-partner-attributes.markdown
@@ -11,7 +11,6 @@ title: Partner Attributes
 | Attribute                     | Type              | Read-Only | Optional | Description
 | :----------                   |:-------------     |:---------:|:--------:|:-------------
 | `company_id`                  | String            |     X     |    X     | unique identifier of this company in your system. (Not to be confused with Gusto's company id)
-| `user_id`                     | String            |     X     |    X     | unique identifier of the company's primary payroll admin in your system.  
 | `grants_rev_share`            | Boolean           |     X     |    X     | whether or not you receive revenue shares on behalf of this company
 
 ## Get partner attributes
@@ -34,7 +33,6 @@ title: Partner Attributes
 ```json
 {
   "company_id": "food-truck-88913",
-  "user_id": "person-815932",
   "grants_rev_share": false
 }
 ```

--- a/_posts/2019-02-27-partner-attributes.markdown
+++ b/_posts/2019-02-27-partner-attributes.markdown
@@ -1,0 +1,41 @@
+---
+permalink: v1/partner_attributes
+layout: sidebar
+title: Partner Attributes
+---
+
+# Partner Attributes
+
+## Attributes
+
+| Attribute                     | Type              | Read-Only | Optional | Description
+| :----------                   |:-------------     |:---------:|:--------:|:-------------
+| `company_id`                  | String            |     X     |    X     | unique identifier of this company in your system. (Not to be confused with Gusto's company id)
+| `user_id`                     | String            |     X     |    X     | unique identifier of the company's primary payroll admin in your system.  
+| `grants_rev_share`            | Boolean           |     X     |    X     | 
+
+## Get partner attributes
+
+**HTTP Method**: `GET`
+
+**Endpoint**: `/v1/partner_attributes/:company_id`
+
+**Returns**: Partner-specific information about the company
+
+**Response Codes**:
+
+| Code        | Description
+| :---------- |:------------- 
+| `200`       | ok
+| `404`       | the company was not found or company had no partner details        
+
+#### Sample Response Body:
+
+```json
+{
+  "company_id": "food-truck-88913",
+  "user_id": "person-815932",
+  "accounting_firm_id": "firm-3193",
+  "grants_rev_share": false
+}
+```


### PR DESCRIPTION
## Purpose

For partnerships that clients can opt in to, the partner might need information about their representation of a company/user to link the Gusto entity to their entity. This change adds a way to make that mapping at a company level.

When a company is provisioned, we'll include 'partner attributes', which will also be queryable in the API. The response will vary by which partner application is calling the endpoint.