### PR TITLE
Add table explaining structure of webhooks requests

### DIFF
--- a/_posts/2018-11-16-webhooks-about.markdown
+++ b/_posts/2018-11-16-webhooks-about.markdown
@@ -8,6 +8,9 @@ layout: sidebar
     Webhooks
 </h1>
 
+Please note: the webhooks API is currently in closed beta, and only available to a limited number of integrations.
+We will begin to roll it out further at some point in the future.
+
 ## About
 Webhooks are a way to get notified when events happen in Gusto so that you do not need to come up with a polling
 strategy for refreshing data in your app.
@@ -24,29 +27,52 @@ describe the resources and provide timestamps to compare to other payloads. Ever
 value that is the serialized entity which matches what you would have gotten if you had used our public API to get
 information on that entity. This way you do not need to query our API every time an event occurs.
 
-The top-level attributes are webhook specific, and an example would look something like:
+## Structure
 
 ```json
 {
   "event_type": "employee.created",
-  "resource_type": "Company",
-  "resource_id": 7757616923531095,
   "entity_type": "Employee",
   "entity_id": 1123581321345589,
-  "timestamp": 1533606328,
-  "entity_attributes": { },
-  "partner_attributes": { }
+  "resource_type": "Company",
+  "resource_id": 7757616923531095,
+  "entity_attributes": { /*...*/ },
+  "partner_attributes": { /*...*/ },
+  "timestamp": 1533606328
 }
 ```
 
-In this example, `timestamp`, `event_type`, and `entity_attributes` are all standard keys to have in a webhooks payload.
-Permissions are based on a resource and its entities. The parent reference is the `resource` while the `entity` is the
-reference to what actually triggered the event.
+| Attribute                     | Type              | Description
+| :----------                   |:-------------     |:-------------
+| `event_type`                  | String            | The type of event that triggered the webhook. Takes the form "{entity_type}:{action_type}". See the "Event Types" section for details.
+| `entity_type`                 | String            | The type of entity that triggered the webhook. This dictates the structure of the `entity_attributes` section, and will match the structure of the corresponding API call (for instance, an entity type of "Employee" will be structured as an [employee](/v1/employees) object).
+| `entity_id`                   | Integer           | The identifier to the entity that can be used to query the traditional API.
+| `resource_type`               | String            | The type of parent entity that caused you to receive the event. For instance, if you have access to a company that added an employee, their company would be the resource. Or, if you instead have permission to an accounting firm with permission to manage their company, that would be the resource.
+| `resource_id`                 | Integer           | The identifier of the parent entity.
+| `entity_attributes`           | Object            | The representation of the entity. Its structure matches the API exactly for the given `entity_type` (except for deprovisioned events, which will only contain an identifier).
+| `partner_attributes`          | Object            | Optional, partner-specific attributes that explain how the entity relates to a partner's system. Will only ever appear on `*.provisioned` events. See the [Partner Attributes](/v1/partner_attributes) section for more information.
+| `timestamp`                   | Integer           | The epoch time when the entity was updated. Webhooks are not guaranteed to be delivered in-order, so you should leverage this to ensure an older event doesn't overwrite a newer one.
 
-Additionally, any events of type `*.provisioned` may have a `partner_attributes` key. If Gusto has a mapping of that
-entity to an entity in your application, those attributes will contain your identifier to that entity. See the 
-[Partner Attributes](/v1/partner_attributes) section for more information on its contents.
+## Event Types
+`provisioned`: Indicates that you will begin to receive webhooks for the entity. This may occur when a user opts
+themselves into your integration or when you provision them through the [Accounts API](/v1/accounts).
 
+`deprovisioned`: Indicates that a user opted out of your integration for the entity. As  such, you will no longer receive
+webhooks or have API access for the entity.
+
+`created`: A user or the Gusto system has created a new entity.
+
+`updated`: A user or the Gusto system has changed a value of an existing entity.
+
+Note that not all **entity** types may trigger all **event** types:
+
+| Entity type                   | Actions that will trigger events
+| :----------                   |:-------------
+| company                       | `provisioned`, `deprovisioned`, `updated`
+| employee                      | `created`, `updated`
+| payroll                       | `created`, `updated`
+| pay_schedule                  | `created`, `updated`
+| location                      | `created`, `updated`
 
 ## Registering
 

--- a/_posts/2018-11-16-webhooks-about.markdown
+++ b/_posts/2018-11-16-webhooks-about.markdown
@@ -50,7 +50,7 @@ information on that entity. This way you do not need to query our API every time
 | `resource_type`               | String            | The type of parent entity that caused you to receive the event. For instance, if you have access to a company that added an employee, their company would be the resource. Or, if you instead have permission to an accounting firm with permission to manage their company, that would be the resource.
 | `resource_id`                 | Integer           | The identifier of the parent entity.
 | `entity_attributes`           | Object            | The representation of the entity. Its structure matches the API exactly for the given `entity_type` (except for deprovisioned events, which will only contain an identifier).
-| `partner_attributes`          | Object            | Optional, partner-specific attributes that explain how the entity relates to a partner's system. Will only ever appear on `*.provisioned` events. See the [Partner Attributes](/v1/partner_attributes) section for more information.
+| `partner_attributes`          | Object            | See the [Partner Attributes](/v1/partner_attributes) section for structure. Contains optional, partner-specific attributes that explain how the entity relates to a partner's system. Will only ever appear on `*.provisioned` events.
 | `timestamp`                   | Integer           | The epoch time when the entity was updated. Webhooks are not guaranteed to be delivered in-order, so you should leverage this to ensure an older event doesn't overwrite a newer one.
 
 ## Event Types


### PR DESCRIPTION
Coming out of comments from #52 

## Purpose
Most explanations of JSON structures in the docs are done in this format. Figured it would be nice to handle this similarly, instead of using just one example payload and some paragraphs.

Also added a disclaimer about Webhooks not being generally available yet.
