### PR TITLE
Make webhooks documentation semi-public

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -95,26 +95,27 @@
              </li>
            </ul>
          </li>
-         <li class="dropdown">
-           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Webhooks</a>
-           <ul class="dropdown-menu">
-             <li>
-               <a href="/v1/webhooks/companies">Companies</a>
-             </li>
-             <li>
-               <a href="/v1/webhooks/employees">Employees</a>
-             </li>
-             <li>
-               <a href="/v1/webhooks/locations">Locations</a>
-             </li>
-             <li>
-               <a href="/v1/webhooks/pay_schedules">Pay Schedules</a>
-             </li>
-             <li>
-               <a href="/v1/webhooks/payrolls">Payrolls</a>
-             </li>
-           </ul>
-         </li>
+         <!--TODO: Uncomment when webhooks become live for all partners-->
+         <!--<li class="dropdown">-->
+           <!--<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Webhooks</a>-->
+           <!--<ul class="dropdown-menu">-->
+             <!--<li>-->
+               <!--<a href="/v1/webhooks/companies">Companies</a>-->
+             <!--</li>-->
+             <!--<li>-->
+               <!--<a href="/v1/webhooks/employees">Employees</a>-->
+             <!--</li>-->
+             <!--<li>-->
+               <!--<a href="/v1/webhooks/locations">Locations</a>-->
+             <!--</li>-->
+             <!--<li>-->
+               <!--<a href="/v1/webhooks/pay_schedules">Pay Schedules</a>-->
+             <!--</li>-->
+             <!--<li>-->
+               <!--<a href="/v1/webhooks/payrolls">Payrolls</a>-->
+             <!--</li>-->
+           <!--</ul>-->
+         <!--</li>-->
          <li>
            <a href="/v1/considerations/versioning">Versioning</a>
          </li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -95,6 +95,26 @@
              </li>
            </ul>
          </li>
+         <li class="dropdown">
+           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Webhooks</a>
+           <ul class="dropdown-menu">
+             <li>
+               <a href="/v1/webhooks/companies">Companies</a>
+             </li>
+             <li>
+               <a href="/v1/webhooks/employees">Employees</a>
+             </li>
+             <li>
+               <a href="/v1/webhooks/locations">Locations</a>
+             </li>
+             <li>
+               <a href="/v1/webhooks/pay_schedules">Pay Schedules</a>
+             </li>
+             <li>
+               <a href="/v1/webhooks/payrolls">Payrolls</a>
+             </li>
+           </ul>
+         </li>
          <li>
            <a href="/v1/considerations/versioning">Versioning</a>
          </li>

--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -102,6 +102,27 @@
                 <a href="/v1/considerations/versioning">Versioning</a>
               </li>
             </ul>
+
+            <h4><a id='title-link' href="/v1/webhooks/about">Webhooks</a></h4>
+            <ul>
+              <ul>
+                <li>
+                  <a href="/v1/webhooks/companies">Companies</a>
+                </li>
+                <li>
+                  <a href="/v1/webhooks/employees">Employees</a>
+                </li>
+                <li>
+                  <a href="/v1/webhooks/locations">Locations</a>
+                </li>
+                <li>
+                  <a href="/v1/webhooks/pay_schedules">Pay Schedules</a>
+                </li>
+                <li>
+                  <a href="/v1/webhooks/payrolls">Payrolls</a>
+                </li>
+              </ul>
+            </ul>
           </div>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-9">

--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -103,26 +103,27 @@
               </li>
             </ul>
 
-            <h4><a id='title-link' href="/v1/webhooks/about">Webhooks</a></h4>
-            <ul>
-              <ul>
-                <li>
-                  <a href="/v1/webhooks/companies">Companies</a>
-                </li>
-                <li>
-                  <a href="/v1/webhooks/employees">Employees</a>
-                </li>
-                <li>
-                  <a href="/v1/webhooks/locations">Locations</a>
-                </li>
-                <li>
-                  <a href="/v1/webhooks/pay_schedules">Pay Schedules</a>
-                </li>
-                <li>
-                  <a href="/v1/webhooks/payrolls">Payrolls</a>
-                </li>
-              </ul>
-            </ul>
+            <!--TODO: Uncomment when webhooks become live for all users-->
+            <!--<h4><a id='title-link' href="/v1/webhooks/about">Webhooks</a></h4>-->
+            <!--<ul>-->
+              <!--<ul>-->
+                <!--<li>-->
+                  <!--<a href="/v1/webhooks/companies">Companies</a>-->
+                <!--</li>-->
+                <!--<li>-->
+                  <!--<a href="/v1/webhooks/employees">Employees</a>-->
+                <!--</li>-->
+                <!--<li>-->
+                  <!--<a href="/v1/webhooks/locations">Locations</a>-->
+                <!--</li>-->
+                <!--<li>-->
+                  <!--<a href="/v1/webhooks/pay_schedules">Pay Schedules</a>-->
+                <!--</li>-->
+                <!--<li>-->
+                  <!--<a href="/v1/webhooks/payrolls">Payrolls</a>-->
+                <!--</li>-->
+              <!--</ul>-->
+            <!--</ul>-->
           </div>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-9">

--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -103,7 +103,7 @@
               </li>
             </ul>
 
-            <!--TODO: Uncomment when webhooks become live for all users-->
+            <!--TODO: Uncomment when webhooks become live for all partners-->
             <!--<h4><a id='title-link' href="/v1/webhooks/about">Webhooks</a></h4>-->
             <!--<ul>-->
               <!--<ul>-->

--- a/_posts/2013-08-10-companies.markdown
+++ b/_posts/2013-08-10-companies.markdown
@@ -90,7 +90,7 @@ layout: sidebar
     "first_name": "Isaiah",
     "last_name"  : "Berlin",
     "phone": "8001234567",
-    "email": "crooked-timber@initech.biz",
+    "email": "crooked-timber@initech.biz"
   }
 }
 ```

--- a/_posts/2018-11-16-webhooks-about.markdown
+++ b/_posts/2018-11-16-webhooks-about.markdown
@@ -1,0 +1,131 @@
+---
+permalink: v1/webhooks/about
+title: Webhooks
+layout: sidebar
+---
+
+<h1 class="block">
+    Webhooks
+</h1>
+
+Please note: the webhooks API is currently in closed beta, and only available to a limited number of integrations.
+We will begin to roll it out further at some point in the future.
+
+## About
+Webhooks are a way to get notified when events happen in Gusto so that you do not need to come up with a polling
+strategy for refreshing data in your app.
+
+Webhooks trigger on certain events and send an HTTP POST payload to the URL that is registered by you for that event.
+You can limit which events trigger a webhook for your registered URLs.
+
+An **event** can be an employee being created for one of your companies, or the company itself being provisioned where
+access to their events were granted to you. You can create alerts in your app for running payroll based on the pay
+schedule, and update it if anything changes.
+
+A **payload** is the body of the request that will be sent to your app when an event happens. The top-level attributes
+describe the resources and provide timestamps to compare to other payloads. Every payload has an `entity_attributes`
+value that is the serialized entity which matches what you would have gotten if you had used our public API to get
+information on that entity. This way you do not need to query our API every time an event occurs.
+
+## Structure
+
+```json
+{
+  "event_type": "employee.created",
+  "entity_type": "Employee",
+  "entity_id": 1123581321345589,
+  "resource_type": "Company",
+  "resource_id": 7757616923531095,
+  "entity_attributes": { /*...*/ },
+  "partner_attributes": { /*...*/ },
+  "timestamp": 1533606328
+}
+```
+
+| Attribute                     | Type              | Description
+| :----------                   |:-------------     |:-------------
+| `event_type`                  | String            | The type of event that triggered the webhook. Takes the form "{entity_type}:{action_type}". See the "Event Types" section for details.
+| `entity_type`                 | String            | The type of entity that triggered the webhook. This dictates the structure of the `entity_attributes` section, and will match the structure of the corresponding API call (for instance, an entity type of "Employee" will be structured as an [employee](/v1/employees) object).
+| `entity_id`                   | Integer           | The identifier to the entity that can be used to query the traditional API.
+| `resource_type`               | String            | The type of parent entity that caused you to receive the event. For instance, if you have access to a company that added an employee, their company would be the resource. Or, if you instead have permission to an accounting firm with permission to manage their company, that would be the resource.
+| `resource_id`                 | Integer           | The identifier of the parent entity.
+| `entity_attributes`           | Object            | The representation of the entity. Its structure matches the API exactly for the given `entity_type` (except for deprovisioned events, which will only contain an identifier).
+| `partner_attributes`          | Object            | See the [Partner Attributes](/v1/partner_attributes) section for structure. Contains optional, partner-specific attributes that explain how the entity relates to a partner's system. Will only ever appear on `*.provisioned` events.
+| `timestamp`                   | Integer           | The epoch time when the entity was updated. Webhooks are not guaranteed to be delivered in-order, so you should leverage this to ensure an older event doesn't overwrite a newer one.
+
+## Event Types
+`provisioned`: Indicates that you will begin to receive webhooks for the entity. This may occur when a user opts
+themselves into your integration or when you provision them through the [Accounts API](/v1/accounts).
+
+`deprovisioned`: Indicates that a user opted out of your integration for the entity. As  such, you will no longer receive
+webhooks or have API access for the entity.
+
+`created`: A user or the Gusto system has created a new entity.
+
+`updated`: A user or the Gusto system has changed a value of an existing entity.
+
+Note that not all **entity** types may trigger all **event** types:
+
+| Entity type                   | Actions that will trigger events
+| :----------                   |:-------------
+| company                       | `provisioned`, `deprovisioned`, `updated`
+| employee                      | `created`, `updated`
+| payroll                       | `created`, `updated`
+| pay_schedule                  | `created`, `updated`
+| location                      | `created`, `updated`
+
+## Registering
+
+While we are working on adding an API endpoint and eventually a GUI for registering an endpoint with our webhooks
+system, the current method is to reach out to Gusto to get your webhooks setup with us.
+
+A webhook registration will require the following:
+
+  - An endpoint URL that we will send events to via `HTTP POST` request
+  - A list of the entities that you would like to receive event notifications for
+    - Current list of supported entities
+      - [Company](/v1/companies)
+      - [Employee](/v1/employees)
+      - [Location](/v1/locations)
+      - [Pay Schedule](/v1/pay_schedules)
+      - [Payroll](/v1/payrolls)
+
+After we have setup your registration and subscribed to the desired entities, we will send you a secret token that can
+be used to verify subsequent notifications sent via the webhook system.
+
+## Verification
+
+Each webhook notification will have a header value that includes a signature you can use to verify the notification
+actually came from Gusto.
+
+The header signature will look something like this:
+
+```
+“X-Gusto-Signature”: "687b8477b067ff52af7c72903254577534434c632b48bac2f1abff170f232f89"
+```
+
+The signature value is a hex digest of the hash-based message authentication code (HMAC-SHA256) computed from the
+stringified JSON payload and the secret key.
+
+Put more simply, all webhook requests will have a 'signature' header with a hash of the request body. You can generate the
+same hash from the request body using the verification token we provide when setting up our integration. As long as that
+token remains secret, any request with a valid signature will have come from us.
+
+As an example, a rails server consuming this webhook might use the following method:
+
+```
+before_action :verify_response_origin
+
+def verify_response_origin
+  computed = OpenSSL::HMAC.hexdigest(
+    OpenSSL::Digest::SHA256.new,
+    GUSTO_VERIFICATION_TOKEN,
+    request.raw_post
+  )
+  actual = request.headers['X-Gusto-Signature']
+
+  if computed != actual
+    render("You're not who you say your are.", status: :bad_request)
+  end
+end
+```

--- a/_posts/2018-11-16-webhooks-companies.markdown
+++ b/_posts/2018-11-16-webhooks-companies.markdown
@@ -1,0 +1,130 @@
+---
+permalink: v1/webhooks/companies
+title: Companies Webhooks
+layout: sidebar
+---
+
+# Companies Webhooks
+
+## Get Company Webhook Notifications
+
+[Webhooks Overview](/v1/webhooks/about)
+
+**Resource**: `Company`
+
+**Entity**: `Company` ([API Reference](/v1/companies))
+
+
+**Event Types**:
+
+- `company.provisioned`
+
+- `company.updated`
+
+- `company.deprovisioned`
+
+**Returns**: Get information about a particular company that was created or updated
+
+```json
+{
+  "event_type": "company.provisioned",
+  "resource_type": "Company",
+  "resource_id": 7757500908984137,
+  "entity_type": "Company",
+  "entity_id": 7757500908984137,
+  "timestamp": 1533606328,
+  "entity_attributes": {
+    "id": 7757500908984137,
+    "name": "Ye Olde Wig Shoppe",
+    "trade_name": "Fezziwig's",
+    "ein": "12-3456789",
+    "entity_type": "LLC",
+    "industry_code": "0001",
+    "locations": [
+      {
+        "id": 3141592653589793,
+        "street_1": "450 Serra Mall",
+        "street_2": "Department of Philosophy",
+        "city": "Stanford",
+        "state": "CA",
+        "zip": "94305"
+      },
+      {
+        "id": 2718281828459045,
+        "street_1": "314 Moses Hall #2390",
+        "street_2": "University of California",
+        "city": "Berkeley",
+        "state": "CA",
+        "zip": "94720"
+      }
+    ],
+    "compensations": {
+      "hourly": [
+        {
+          "name": "Regular Hours",
+          "multiple": 1
+        },
+        {
+          "name": "Overtime",
+          "multiple": 1.5
+        },
+        {
+          "name": "Double Overtime",
+          "multiple": 2
+        }
+      ],
+      "fixed": [
+        {
+          "name": "Bonus"
+        },
+        {
+          "name": "Commission"
+        }
+      ],
+      "paid_time_off": [
+        {
+          "name": "Vacation Hours"
+        },
+        {
+          "name": "Sick Hours"
+        }
+      ]
+    },
+    "primary_signatory": {
+      "first_name": "Isaiah",
+      "middle_initial": "H",
+      "last_name"  : "Berlin",
+      "phone": "8001234567",
+      "email": "crooked-timber@initech.biz",
+      "home_address": {
+        "street_1": "314 Moses Hall #2390",
+        "street_2": "University of California",
+        "city": "Berkeley",
+        "state": "CA",
+        "zip": "94720",
+        "country": "USA"
+      }
+    },
+    "primary_payroll_admin": {
+      "first_name": "Isaiah",
+      "last_name"  : "Berlin",
+      "phone": "8001234567",
+      "email": "crooked-timber@initech.biz"
+    }
+  }
+}
+```
+
+```json
+{
+  "event_type": "company.deprovisioned",
+  "resource_type": "Company",
+  "resource_id": 7757500908984137,
+  "entity_type": "Company",
+  "entity_id": 7757500908984137,
+  "timestamp": 1533606328,
+  "entity_attributes": {
+    "company_id": 7757500908984137
+  }
+}
+```

--- a/_posts/2018-11-16-webhooks-employees.markdown
+++ b/_posts/2018-11-16-webhooks-employees.markdown
@@ -1,0 +1,87 @@
+---
+permalink: v1/webhooks/employees
+title: Employees Webhooks
+layout: sidebar
+---
+
+# Employees Webhooks
+
+## Get Employee Webhook Notifications
+[Webhooks Overview](/v1/webhooks/about)
+
+**Resource**: `Company`
+
+**Entity**: `Employee` ([API Reference](/v1/employees))
+
+
+**Event Types**:
+
+- `employee.created`
+
+- `employee.updated`
+
+**Returns**: Get information about a particular employee that was created or updated
+
+```json
+{
+  "event_type": "employee.created",
+  "resource_type": "Company",
+  "resource_id": 7757616923531095,
+  "entity_type": "Employee",
+  "entity_id": 1123581321345589,
+  "timestamp": 1533606328,
+  "entity_attributes": {
+    "id": 1123581321345589,
+    "version": "db0edd04aaac4506f7edab03ac855d56",
+    "first_name": "Soren",
+    "middle_initial": "A",
+    "last_name": "Kierkegaard",
+    "company_id": 7757616923531095,
+    "manager_id": 7757869431804236,
+    "department": "Marketing",
+    "email": "knight0faith@initech.biz",
+    "ssn": "XXX-XX-2940",
+    "date_of_birth": "1990-05-05",
+    "jobs": [
+      {
+        "id": 1,
+        "title": "Underwater Basket Weaver",
+        "rate": "80000.00",
+        "payment_unit": "Year",
+        "location_id": 3141592653589793
+      }
+    ],
+    "home_address": {
+      "id": 1402342024000,
+      "version": "fe75bd065ff48b91c35fe8ff842f986c",
+      "employee_id": 1123581321345589,
+      "street_1": "425 2nd Street",
+      "street_2": "Suite 602",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94107",
+      "country": "USA"
+    },
+    "garnishments": [
+      {
+        "id": 1363316538400333,
+        "version": "52b7c567242cb7452e89ba2bc02cb476",
+        "employee_id": 8964216891236743,
+        "active": true,
+        "amount": "8.00",
+        "description": "Company loan to employee",
+        "court_ordered": false,
+        "times": 5,
+        "recurring": false,
+        "annual_maximum": null,
+        "pay_period_maximum": "100.00",
+        "deduct_as_percentage": true
+      }
+    ],
+    "eligible_paid_time_off": [],
+    "onboarded": true,
+    "terminated": false,
+    "terminations": []
+  }
+}
+```

--- a/_posts/2018-11-16-webhooks-locations.markdown
+++ b/_posts/2018-11-16-webhooks-locations.markdown
@@ -1,0 +1,46 @@
+---
+permalink: v1/webhooks/locations
+title: Locations Webhooks
+layout: sidebar
+---
+
+# Locations Webhooks
+
+## Get Location Webhook Notifications
+[Webhooks Overview](/v1/webhooks/about)
+
+**Resource**: `Company`
+
+**Entity**: `Location` ([API Reference](/v1/locations))
+
+
+**Event Types**:
+
+- `location.created`
+
+- `location.updated`
+
+**Returns**: Get information about a particular location that was created or updated
+
+```json
+{
+  "event_type": "location.created",
+  "resource_type": "Company",
+  "resource_id": 1402341716000,
+  "entity_type": "Location",
+  "entity_id": 1402342024000,
+  "timestamp": 1533606328,
+  "entity_attributes": {
+    "id": 1402342024000,
+    "version": "fe75bd065ff48b91c35fe8ff842f986c",
+    "phone_number": "8009360383",
+    "company_id": 1402341716000,
+    "street_1": "21 Stillman Street",
+    "street_2": "Apartment 6",
+    "city": "San Francisco",
+    "state": "CA",
+    "zip": "94107",
+    "country": "USA"
+  }
+}
+```

--- a/_posts/2018-11-16-webhooks-pay-schedules.markdown
+++ b/_posts/2018-11-16-webhooks-pay-schedules.markdown
@@ -1,0 +1,48 @@
+---
+permalink: v1/webhooks/pay_schedules
+title: Pay Schedules Webhooks
+layout: sidebar
+---
+
+# Pay Schedules Webhooks
+
+## Get Pay Schedule Webhook Notifications
+[Webhooks Overview](/v1/webhooks/about)
+
+**Resource**: `Company`
+
+**Entity**: `PaySchedule` ([API Reference](/v1/pay_schedules))
+
+
+**Event Types**:
+
+- `pay_schedule.created`
+
+- `pay_schedule.updated`
+
+**Note** The primary use case for this event is to get Pay Periods. There are no events for Pay Periods because they are virtual and computed every time. You can use this event to in turn query our public API endpoint for a list of Pay Periods that you need for a given date range. If the Pay Schedule does not change, then the Pay Periods can be safely assumed to remain constant.
+
+It is not advised to try and compute the Pay Schedules on your own instead of querying our API. For a monthly pay schedule alone we have 4 different ways of computing it depending on legacy logic and different needs unique to each company. Using our public API allows for the logic to remain constant across services.
+
+You can read more about the Pay Period endpoint in our API [here](http://docs.gusto.com/v1/pay_periods).
+
+**Returns**: Get information about a particular pay schedule that was created or updated
+
+```json
+{
+  "event_type": "pay_schedule.created",
+  "resource_type": "Company",
+  "resource_id": 7757616923531095,
+  "entity_type": "PaySchedule",
+  "entity_id": 1,
+  "timestamp": 1533606328,
+  "entity_attributes": {
+    "id": 1,
+    "frequency": "Every other week",
+    "anchor_pay_date": "2018-01-12",
+    "day_1": null,
+    "day_2": null,
+    "name": "Hourly"
+  }
+}
+```

--- a/_posts/2018-11-16-webhooks-payrolls.markdown
+++ b/_posts/2018-11-16-webhooks-payrolls.markdown
@@ -1,0 +1,140 @@
+---
+permalink: v1/webhooks/payrolls
+title: Payrolls Webhooks
+layout: sidebar
+---
+
+# Payrolls Webhooks
+
+## Get Payroll Webhook Notifications
+[Webhooks Overview](/v1/webhooks/about)
+
+**Resource**: `Company`
+
+**Entity**: `Payroll` ([API Reference](/v1/payrolls))
+
+
+**Event Types**:
+
+- `payroll.created`
+
+- `payroll.updated`
+
+**Note** We do not currently have an endpoint for fetching a singular payroll. Until this gets developed, fetching the equivalent data from the public API will require fetching from the index endpoint. You can read more about scoping the request down to reduce the amount of noise [here](http://docs.gusto.com/v1/payrolls). Specifically, you may find the optional `start_date` and `end_date` useful for retrieving a specific payroll from this webhook event.
+
+**Returns**: Get information about a particular payroll that was created or updated
+
+```json
+{
+  "event_type": "payroll.created",
+  "resource_type": "Company",
+  "resource_id": 7757616923531095,
+  "entity_type": "Payroll",
+  "entity_id": 1,
+  "timestamp": 1533606328,
+  "entity_attributes": {
+    "version": "19289df18e6e20f797de4a585ea5a91535c7ddf7",
+    "payroll_deadline": "2018-02-18",
+    "processed": true,
+    "pay_period": {
+      "start_date": "2018-02-01",
+      "end_date": "2018-02-15",
+      "pay_schedule_id": 7757500908984137
+    },
+    "totals": {
+      "company_debit": "2791.25",
+      "reimbursements": "0.00",
+      "net_pay": "1953.31",
+      "correction": "0.00",
+      "employer_taxes": "191.25",
+      "employee_taxes": "646.69",
+      "benefits": "0.0"
+    },
+    "employee_compensations": [
+      {
+        "employee_id": 1123581321345589,
+        "gross_pay": "2791.25",
+        "net_pay": "1953.31",
+        "payment_method": "Direct Deposit",
+        "fixed_compensations": [
+          {
+            "name": "Bonus",
+            "amount": "100.00",
+            "job_id": 1
+          },
+          {
+            "name": "Reimbursement",
+            "amount": "100.00",
+            "job_id": 1
+          }
+        ],
+        "hourly_compensations": [
+          {
+            "name": "Regular Hours",
+            "hours": "40.000",
+            "job_id": 1,
+            "compensation_multiplier": 1
+          },
+          {
+            "name": "Overtime",
+            "hours": "15.000",
+            "job_id": 1,
+            "compensation_multiplier": 1.5
+          },
+          {
+            "name": "Double Overtime",
+            "hours": "0.000",
+            "job_id": 1,
+            "compensation_multiplier": 2
+          },
+          {
+            "name": "Regular Hours",
+            "hours": "40.000",
+            "job_id": 2,
+            "compensation_multiplier": 1
+          },
+          {
+            "name": "Overtime",
+            "hours": "5.000",
+            "job_id": 2,
+            "compensation_multiplier": 1.5
+          },
+          {
+            "name": "Double Overtime",
+            "hours": "0.000",
+            "job_id": 2,
+            "compensation_multiplier": 2
+          }
+        ],
+        "paid_time_off": [
+          {
+            "name": "Vacation Hours",
+            "hours": "20.000"
+          },
+          {
+            "name": "Sick Hours",
+            "hours": "0.000"
+          },
+          {
+            "name": "Holiday Hours",
+            "hours": "0.000"
+          }
+        ],
+        "benefits": [],
+        "taxes": [
+          {
+            "name": "Federal Income Tax",
+            "employer": false,
+            "amount": "646.69"
+          },
+          {
+            "name": "Social Security",
+            "employer": true,
+            "amount": "191.25"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/_posts/2019-02-27-partner-attributes.markdown
+++ b/_posts/2019-02-27-partner-attributes.markdown
@@ -1,0 +1,32 @@
+---
+permalink: v1/partner_attributes
+layout: sidebar
+title: Partner Attributes
+---
+
+# Partner Attributes
+
+## Attributes
+
+| Attribute                     | Type              | Read-Only | Optional | Description
+| :----------                   |:-------------     |:---------:|:--------:|:-------------
+| `grants_rev_share`            | Boolean           |     X     |    X     | true if you are receiving revenue sharing on behalf of this company
+| `mapping`                     | Object            |     X     |    X     | how the company relates to an entity in your system
+| `mapping:gusto:company_id`    | Integer           |     X     |    X     | unique identifier of this company in our system
+| `mapping:partner:company_id`  | String            |     X     |    X     | unique identifier of this company in your system (optional; partner-dependent)
+
+#### Sample Body:
+
+```json
+{
+  "grants_rev_share": false,
+  "mapping": {
+    "partner": {
+      "company_id": "a0c5e109-1a45-40e8-96c9-4fc83f8f08b6"
+    },
+    "gusto": {
+      "company_id": 7389117231658670
+    }
+  }
+}
+```

--- a/css/gusto.css
+++ b/css/gusto.css
@@ -58,10 +58,19 @@ a:hover {
     -webkit-transition: all 125ms ease-in-out;
 }
 
+#title-link {
+  color: #25D6C9;
+}
+
 a:focus,
 a:visited {
     color: #1679C4;
 }
+
+h4 a:focus {
+  color: #25D6C9;
+}
+
 a:hover {
     color: #25D6C9;
 }


### PR DESCRIPTION
## Purpose

The Webhooks API is not yet live. We don't want to make the documentation totally public so that partners don't start asking for access. However, in the interest of keeping the documentation up-to-date and avoiding merge conflicts down the road, let's discontinue the long-lived `jps-webhooks` branch and instead just hide the webhooks nav items until we're ready to release them. 

This also lets us share the URLs to the webhooks docs directly instead of needing to make PDFs for partners with the documentation.