### PR TITLE
Only allow company addresses in locations endpoint

### DIFF
--- a/_posts/2014-08-11-locations.markdown
+++ b/_posts/2014-08-11-locations.markdown
@@ -7,11 +7,7 @@ title: Locations
 
 # Locations
 
-Locations represent addresses inside Gusto. Locations may belong to a number
-of objects, from employees and contractors to companies, and return their
-respective association's id via an appropriately named attribute. For example, a
-<a href="/v1/company_locations">company location</a> will have a `"company_id"`
-property while an employee's home addres will instead have an `"employee_id"`.
+Locations represent company addresses inside Gusto.
 
 ## Attributes
 
@@ -19,8 +15,7 @@ property while an employee's home addres will instead have an `"employee_id"`.
 | :----------                   |:-------------     |:---------:|:--------:|:--------|:-------------
 | `id`                          | Integer           |     X     |          |         | the unique identifier of this company location
 | `version`                     | String            |     X     |          |         | version of this object. See <a href="/v1/considerations/versioning">the versioning documentation</a> for a more in depth explaination of versions
-| `company_id`                 | Integer            |     X     |     X    |         | id for the company to which this location belongs. Only included if address belongs to a company.
-| `employee_id`                 | Integer           |     X     |     X    |         | id for the employee to which this location belongs. Only included if address belongs to an employee.
+| `company_id`                 | Integer            |     X     |          |         | id for the company to which this location belongs. Only included if address belongs to a company.
 | `phone_number`                | String            |           |          |         | phone number for this location. Required for company locations, optional for employee locations
 | `street_1`                    | String            |           |          |         | first line of the address
 | `street_2`                    | String            |           |    X     | null    | second line of the address


### PR DESCRIPTION
I ran the following query in redshift:
```
SELECT l.action,
       CASE
           WHEN a.id IS NULL THEN 'NULL'
           ELSE a.addressable_type
       END AS address,
       count(*) AS cnt
FROM eng_production.logentries_requests AS l
LEFT JOIN zenpayroll_production_no_pii.addresses AS a ON a.id = substring(l.path, 15)
WHERE controller = 'Api::V1::LocationsController'
GROUP BY address,
         l.action;
```

With the following result:
<img width="1208" alt="Screen Shot 2020-02-06 at 10 11 16 PM" src="https://user-images.githubusercontent.com/32997/74049221-ae3cbd80-49a1-11ea-9015-d6e7d0e18338.png">

It shows that this endpoint has only ever been used by our partners with company addresses, the occurrences of NULL indicates addresses that have been deleted from our system.

A subsequent PR in ZP will error out when this endpoint is used with any other address type.