### PR TITLE
Document rate limits

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -17,6 +17,17 @@
      <div class="collapse navbar-collapse" id="gusto-navbar">
        <ul class="nav navbar-nav navbar-left">
          <li class="dropdown">
+           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Basics</a>
+           <ul class="dropdown-menu">
+             <li>
+               <a href="/v1/basics/authentication">Authentication</a>
+             </li>
+             <li>
+               <a href="/v1/basics/rate-limits">Rate Limits</a>
+             </li>
+           </ul>
+         </li>
+         <li class="dropdown">
            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Examples</a>
            <ul class="dropdown-menu">
              <li>
@@ -24,9 +35,6 @@
              </li>
              <li>
                <a href="/v1/examples/syncing-employees">Syncing Employees</a>
-             </li>
-             <li>
-               <a href="/v1/examples/authentication">Authentication</a>
              </li>
            </ul>
          </li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -18,7 +18,7 @@
         </a>
       </li>
       <li>
-        <a href="/v1/examples/authentication">
+        <a href="/v1/basics/authentication">
           <i class="icon-key"></i> Authentication
         </a>
       </li>

--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -16,6 +16,16 @@
 
         <div class="md-hidden col-md-3">
           <div class="sub-menu">
+            <h4>Basics</h4>
+            <ul>
+              <li>
+                <a href="/v1/basics/authentication">Authentication</a>
+              </li>
+              <li>
+                <a href="/v1/basics/rate-limits">Rate Limits</a>
+              </li>
+            </ul>
+
             <h4>Examples</h4>
             <ul>
               <li>
@@ -26,9 +36,6 @@
               </li>
               <li>
                 <a href="/v1/examples/creating-a-company">Creating a Company</a>
-              </li>
-              <li>
-                <a href="/v1/examples/authentication">Authentication</a>
               </li>
             </ul>
 

--- a/_posts/2013-09-26-authentication.markdown
+++ b/_posts/2013-09-26-authentication.markdown
@@ -1,5 +1,5 @@
 ---
-permalink: v1/examples/authentication
+permalink: v1/basics/authentication
 layout: sidebar
 title: Authentication Example
 ---

--- a/_posts/2013-09-26-syncing-employees-example.markdown
+++ b/_posts/2013-09-26-syncing-employees-example.markdown
@@ -8,7 +8,7 @@ title: Syncing Employees Example
 
 ## Are We Talking About The Same People?
 
-You have successfully <a href="/v1/examples/authentication">integrated with OAuth</a>, gotten back the authenticated
+You have successfully <a href="/v1/basics/authentication">integrated with OAuth</a>, gotten back the authenticated
 companies for the <a href="/v1/current_user">current user</a>, and fetched the
 <a href="/v1/companies">company information</a>.
 

--- a/_posts/2013-09-30-updating-payrolls-example.markdown
+++ b/_posts/2013-09-30-updating-payrolls-example.markdown
@@ -14,7 +14,7 @@ Here we'll walk through updating the payroll information for one employee and ho
 
 We'll be using Ruby, with inefficient code, but the purpose of this example is to outline the flow rather than provide a production-ready implementation.
 
-These examples will assume an <a href="/v1/examples/authentication">authenticated</a> application and will also assume the bearer token is being specified via the `Authorization` HTTP header.
+These examples will assume an <a href="/v1/basics/authentication">authenticated</a> application and will also assume the bearer token is being specified via the `Authorization` HTTP header.
 
 ### Get Unprocessed Payroll
 

--- a/_posts/2014-08-01-accounts.markdown
+++ b/_posts/2014-08-01-accounts.markdown
@@ -11,7 +11,7 @@ The accounts API is for creating accounts for new customers on Gusto. With
 a minimum amount of information, partners may create a user, company, and the
 related permissions to go from setup onboarding information.
 
-**Note** This endpoint requires authorization via [Token Authentication](/v1/examples/authentication#api-token-authentication) with an API token. Normal OAuth credentials will _not_ allow
+**Note** This endpoint requires authorization via [Token Authentication](/v1/basics/authentication#api-token-authentication) with an API token. Normal OAuth credentials will _not_ allow
 account creation.
 
 ## Attributes

--- a/_posts/2018-11-16-webhooks-about.markdown
+++ b/_posts/2018-11-16-webhooks-about.markdown
@@ -49,13 +49,12 @@ information on that entity. This way you do not need to query our API every time
 | `entity_id`                   | Integer           | The identifier to the entity that can be used to query the traditional API.
 | `resource_type`               | String            | The type of parent entity that caused you to receive the event. For instance, if you have access to a company that added an employee, their company would be the resource. Or, if you instead have permission to an accounting firm with permission to manage their company, that would be the resource.
 | `resource_id`                 | Integer           | The identifier of the parent entity.
-| `entity_attributes`           | Object            | The representation of the entity. Its structure matches the API exactly for the given `entity_type` (except for deprovisioned events, which will only contain an identifier).
+| `entity_attributes`           | Object            | The representation of the entity. Its structure matches the API exactly for the given `entity_type` (except for `deprovisioned` events, which will only contain an identifier).
 | `partner_attributes`          | Object            | See the [Partner Attributes](/v1/partner_attributes) section for structure. Contains optional, partner-specific attributes that explain how the entity relates to a partner's system. Will only ever appear on `*.provisioned` events.
 | `timestamp`                   | Integer           | The epoch time when the entity was updated. Webhooks are not guaranteed to be delivered in-order, so you should leverage this to ensure an older event doesn't overwrite a newer one.
 
 ## Event Types
-`provisioned`: Indicates that you will begin to receive webhooks for the entity. This may occur when a user opts
-themselves into your integration or when you provision them through the [Accounts API](/v1/accounts).
+`provisioned`: Indicates that a user opted into your integration for the entity. You will begin to receive webhooks on behalf of this entity.
 
 `deprovisioned`: Indicates that a user opted out of your integration for the entity. As  such, you will no longer receive
 webhooks or have API access for the entity.

--- a/_posts/2020-03-18-rate-limits.markdown
+++ b/_posts/2020-03-18-rate-limits.markdown
@@ -6,6 +6,10 @@ layout: sidebar
 
 # Rate Limits
 
-(Note: Applications created prior to March 1, 2020 are exempt from these rate limits.)
+(Note: Applications created prior to March 1, 2020 are exempt from any rate limiting.)
 
-## Overview
+Excessive calls to the Gusto API over a short period of time are subject to rate limits, scoped to an application-user pair. What this means is that for a given application, you will be limited to 60 calls per minute for each user who has connected an integration.
+
+Rate limits are enforced as a **rolling window**, meaning that the 60 second window begins after receipt of an initial API call, and continues until that 60 seconds has elapsed. A new window will begin after another API request is received.
+
+Should you make more than 60 requests on behalf of a single user over the course of a minute, you will begin to receive responses with HTTP status `429: Too Many Requests` until that 60 second window has elapsed.

--- a/_posts/2020-03-18-rate-limits.markdown
+++ b/_posts/2020-03-18-rate-limits.markdown
@@ -8,8 +8,6 @@ layout: sidebar
 
 (Note: Applications created prior to March 1, 2020 are exempt from any rate limiting.)
 
-Excessive calls to the Gusto API over a short period of time are subject to rate limits, scoped to an application-user pair. What this means is that for a given application, you will be limited to 60 calls per minute for each user who has connected an integration.
+Excessive calls to the Gusto API over a short period of time are subject to rate limits. Rate limits are enforced in a 60-second **rolling window**. The window opens after your first API call and closes after 60 seconds has elapsed. A new window opens when you send your next API request.
 
-Rate limits are enforced as a **rolling window**, meaning that the 60 second window begins after receipt of an initial API call, and continues until that 60 seconds has elapsed. A new window will begin after another API request is received.
-
-Should you make more than 60 requests on behalf of a single user over the course of a minute, you will begin to receive responses with HTTP status `429: Too Many Requests` until that 60 second window has elapsed.
+Rate limits are scoped on an application-user pair. This means that you can make 60 calls per minute on behalf of each user that has connected your application. If you make more than 60 calls for a single user in the window, subsequent requests will return responses with the HTTP status `429: Too Many Requests` until the window closes.

--- a/_posts/2020-03-18-rate-limits.markdown
+++ b/_posts/2020-03-18-rate-limits.markdown
@@ -1,0 +1,11 @@
+---
+permalink: /v1/basics/rate-limits
+title: Rate Limits
+layout: sidebar
+---
+
+# Rate Limits
+
+(Note: Applications created prior to March 1, 2020 are exempt from these rate limits.)
+
+## Overview

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: sidebar
 
 <p>Gusto has a closed API system and a full near-term roadmap.  We do occasionally support new integrations for products that could potentially benefit many or all of our small businesses.  If you'd like to be considered for a future integration partnership, please email partnerships@gusto.com.</p>
 
-<p>Existing partners have been given API credentials. These include the application id and secret necessary to interact with any part of the Gusto API. Next, you'll want to successfully authenticate a user using OAuth. The <a href="/v1/examples/authentication">Authentication Example</a> has everything you need to get started. </p>
+<p>Existing partners have been given API credentials. These include the application id and secret necessary to interact with any part of the Gusto API. Next, you'll want to successfully authenticate a user using OAuth. The <a href="/v1/basics/authentication">Authentication Example</a> has everything you need to get started. </p>
 
 
 


### PR DESCRIPTION
Now that we're going to begin rate limiting new partners, we should add documentation to make them aware of how to comply with them. With this change:

* Create new section in side nav for 'Basics': this includes things that apply to all endpoints. Authorization page has been added to this section as well.
* Add page on rate limiting, outlining which partners are affected and how to comply
* Unrelated: update verbage around webhooks provisioned/deprovisioned event types

![image](https://user-images.githubusercontent.com/1522331/77112804-44c3bc00-69ef-11ea-9f58-e78e38fbcd7c.png)
