### PR TITLE
Remove correction from documentation since it's always zero

### DIFF
--- a/_posts/2013-08-10-payrolls.markdown
+++ b/_posts/2013-08-10-payrolls.markdown
@@ -34,7 +34,6 @@ layout: sidebar
       "company_debit": "2791.25",
       "reimbursements": "0.00",
       "net_pay": "1953.31",
-      "correction": "0.00",
       "employer_taxes": "191.25",
       "employee_taxes": "646.69",
       "benefits": "0.0",
@@ -160,7 +159,6 @@ layout: sidebar
 | `company_debit`           | the total company debit for the payroll
 | `reimbursements`          | the total reimbursements for the payroll
 | `net_pay`                 | the net pay amount for the payroll
-| `correction`              | the amount of correction for the payroll
 | `employer_taxes`          | the amount of employer paid taxes for the payroll
 | `employee_taxes`          | the amount of employee paid taxes for the payroll
 | `benefits`                | the amount of company contributed benefits for the payroll
@@ -240,7 +238,6 @@ You may provide all, none, or any combination of them to scope the returned data
     "company_debit": "2791.25",
     "reimbursements": "0.00",
     "net_pay": "1953.31",
-    "correction": "0.00",
     "employer_taxes": "191.25",
     "employee_taxes": "646.69",
     "benefits": "0.0",
@@ -365,7 +362,6 @@ You may provide all, none, or any combination of them to scope the returned data
 | `company_debit`           | the total company debit for the payroll
 | `reimbursements`          | the total reimbursements for the payroll
 | `net_pay`                 | the net pay amount for the payroll
-| `correction`              | the amount of correction for the payroll
 | `employer_taxes`          | the amount of employer paid taxes for the payroll
 | `employee_taxes`          | the amount of employee paid taxes for the payroll
 | `benefits`                | the amount of company contributed benefits for the payroll

--- a/_posts/2018-11-16-webhooks-payrolls.markdown
+++ b/_posts/2018-11-16-webhooks-payrolls.markdown
@@ -45,7 +45,6 @@ layout: sidebar
       "company_debit": "2791.25",
       "reimbursements": "0.00",
       "net_pay": "1953.31",
-      "correction": "0.00",
       "employer_taxes": "191.25",
       "employee_taxes": "646.69",
       "benefits": "0.0"


### PR DESCRIPTION
### Purpose 
Currently, we always return 0 for "correction" in the API. Since this field is effectively dead-but-not-removed, let's at least remove it from the docs to prevent confusion.

See the thread and line of code linked below for more detail.

* https://gustohq.slack.com/archives/CFVGQ688H/p1585598092019800
* https://github.com/Gusto/zenpayroll/blob/b4e1753c07e22d291d0c3ea7af2b6e49ef08bc93/app/views/api/v1/payrolls/payroll_admin/show.json.rabl#L25