### PR TITLE
Update documentation to emphasize the complexities of multiple pay schedules

### DIFF
--- a/_posts/2013-09-30-updating-payrolls-example.markdown
+++ b/_posts/2013-09-30-updating-payrolls-example.markdown
@@ -249,4 +249,4 @@ This means that you will need to refetch the payroll data for that pay period an
   GET https://api.gusto.com/v1/companies/94158/payrolls?processed=false&start_date={{ site.time | date: '%Y' }}-01-16&end_date={{ site.time | date: '%Y' }}-01-31
 ```
 
-This should only return that one payroll and we can recompute the data specifically for that pay period. Do not simply copy over the new `version` and resubmit, as you'll likely be overwriting information that the user, an internal Gusto process, or another 3rd party application. This can lead to incorrect pay, miscalculated taxes, and upset users 
+This should only return that one payroll and we can recompute the data specifically for that pay period. Do not simply copy over the new `version` and resubmit, as you'll likely be overwriting information that the user, an internal Gusto process, or another 3rd party application. This can lead to incorrect pay, miscalculated taxes, and upset users.

--- a/_posts/2013-09-30-updating-payrolls-example.markdown
+++ b/_posts/2013-09-30-updating-payrolls-example.markdown
@@ -90,6 +90,47 @@ json_response = [
     ]
   },
   {
+    "version" => "19289df18e6e20f797de4a585ea5a91535c7ddf7",
+    "payroll_deadline" => "{{ site.time | date: '%Y' }}-01-18",
+    "processed" => false,
+    "pay_period" => {
+      "start_date" => "{{ site.time | date: '%Y' }}-01-01",
+      "end_date" => "{{ site.time | date: '%Y' }}-01-15",
+      "pay_schedule_id" => 7757500542932121
+    },
+    "employee_compensations" => [
+      {
+        "employee_id" => 1323581379452363,
+        "fixed_compensations" => [
+          {
+            "name" => "Bonus",
+            "amount" => "0.00",
+            "job_id" => 1
+          },
+          {
+            "name" => "Commission",
+            "amount" => "0.00",
+            "job_id" => 1
+          },
+          {
+            "name" => "Reimbursement",
+            "amount" => "0.00",
+            "job_id" => 1
+          }
+        ],
+        "hourly_compensations" => [
+          {
+            "name" => "Regular Hours",
+            "hours" => "0.000",
+            "job_id" => 1,
+            "compensation_multiplier" => 1
+          }
+        ],
+        "paid_time_off" => []
+      }
+    ]
+  },
+  {
     "version" => "fb38ac6fdebea9646c4ac2e50ad27a21",
     "payroll_deadline" => "{{ site.time | date: '%Y' }}-02-03",
     "processed" => false,
@@ -129,22 +170,65 @@ json_response = [
         "paid_time_off" => []
       }
     ]
+  },
+  {
+    "version" => "19289df18e6e20f797de4a585ea5a91535c7fff2",
+    "payroll_deadline" => "{{ site.time | date: '%Y' }}-02-03",
+    "processed" => false,
+    "pay_period" => {
+      "start_date" => "{{ site.time | date: '%Y' }}-01-16",
+      "end_date" => "{{ site.time | date: '%Y' }}-01-31",
+      "pay_schedule_id" => 7757500542932121
+    },
+    "employee_compensations" => [
+      {
+        "employee_id" => 1323581379452363,
+        "fixed_compensations" => [
+          {
+            "name" => "Bonus",
+            "amount" => "0.00",
+            "job_id" => 1
+          },
+          {
+            "name" => "Commission",
+            "amount" => "0.00",
+            "job_id" => 1
+          },
+          {
+            "name" => "Reimbursement",
+            "amount" => "0.00",
+            "job_id" => 1
+          }
+        ],
+        "hourly_compensations" => [
+          {
+            "name" => "Regular Hours",
+            "hours" => "0.000",
+            "job_id" => 1,
+            "compensation_multiplier" => 1
+          }
+        ],
+        "paid_time_off" => []
+      }
+    ]
   }
 ]
 
 ```
 
-This company seems to be on a semi-monthly pay schedule, paying their employees on the 15th and end of the month. We've already <a href="/v1/examples/syncing-employees">sync'd employees</a> and know that we are looking for `employee_id` 1123581321345589.
+This company seems to have two semi-monthly pay schedules, both paying their employees on the 15th and end of the month. 
+
+We've already <a href="/v1/examples/syncing-employees">sync'd employees</a> and know that we are looking for `employee_id` 1123581321345589.
 
 Looks like she is eligible for two types of fixed compensations, one type of hourly compensation, and no PTO.
 
-Now we need to match up the totals from our data with the pay period it fits in. Because all of our dates are formatted according to [RFC-3339](http://tools.ietf.org/html/rfc3339#section-5.1), we can take advantage of simple string comparisions.
+Now we need to match up the totals from our data with the pay period and version it fits in. Because all of our dates are formatted according to [RFC-3339](http://tools.ietf.org/html/rfc3339#section-5.1), we can take advantage of simple string comparisions.
 
 
 ```ruby
 
 # For each of the returned payrolls,
-# group all work data that occured during
+# group all work data that occurred during
 # that pay period
 
 hourly_data_grouped_by_pay_period = json_response.reduce([]) do |grouped_data, payroll_json|
@@ -172,10 +256,16 @@ end
 
 Now we need to build up the information to send to the Update Payrolls endpoint. All that is required is the version and the compensation information.
 
+It's possible for a company to have multiple pay schedules, that's why we don't assume an employee 
+
 ```ruby
 updated_payroll_data = json_response.map.with_index do |payroll_json, index|
   # Find the compensation for Patricia Churchland
   churchland_compensation = payroll_json["employee_compensations"].detect { |compensation_json| compensation_json["employee_id"] == employee_id }
+  
+  # Patricia Churchland isn't part of this payroll, this could happen if the company has multiple pay schedules.
+  # We'll want to iterate until we find the appropriate payroll 
+  next unless churchland_compensation
 
   # Find the 'Regular Hours' hourly compensation
   regular_hours_compensation = churchland_compensation["hourly_compensations"].detect { |hourly_compensation| hourly_compensation["name"] == 'Regular Hours' }
@@ -192,7 +282,7 @@ updated_payroll_data = json_response.map.with_index do |payroll_json, index|
       }
     ]
   }
-end
+end.compact
 ```
 
 Obviously our implementation would have to adapt if we were updating multiple employees simultaneously, or wanted to include multiple types of compensation, but that is the basic flow.

--- a/_posts/2018-04-24-pay_schedules.markdown
+++ b/_posts/2018-04-24-pay_schedules.markdown
@@ -18,7 +18,7 @@ when they should be paid. A company can have multiple pay schedules.
 | `anchor_pay_date`                 | String           |     X     |          |         | The first date that employees on this pay schedule are paid with Gusto
 | `day_1`                      | Integer           |     X     |     X    |         | An integer between 1 and 31 indicating the first day of the month that employees are paid. This field is only relevant for pay schedules with the "Twice per month" and "Monthly" frequencies. It will be null for pay schedules with other frequencies.
 | `day_2`                      | Integer           |     X     |     X    |         | An integer between 1 and 31 indicating the second day of the month that employees are paid. This field is the second pay date for pay schedules with the "Twice per month" frequency. It will be null for pay schedules with other frequencies.
-| `name`                      | String           |     X     |     X     |         | 'Hourly' when the pay schedule is for hourly employees. 'Salaried' when the pay schedule is for salaried employees. It will be null when the pay schedule is for all employees.
+| `name`                      | String           |     X     |     X     |         | A name describing the pay group, for example, "Hourly" when all hourly employees are assigned to it, or the name of the department if the pay schedule is for an entire department. The name of the schedule is dependent on how a company decides to group employees into pay schedules and should not be used programmatically to make any assumptions.
 
 ## Get a pay schedule
 
@@ -55,19 +55,27 @@ when they should be paid. A company can have multiple pay schedules.
 [
   {
     "id": 1,
-    "frequency": "Twice per week",
-    "anchor_pay_date": "2018-01-12",
-    "day_1": null,
-    "day_2": null,
-    "name": "Hourly"
+    "frequency": "Twice per month",
+    "anchor_pay_date": "2020-05-15",
+    "day_1": 15,
+    "day_2": 31,
+    "name": "Engineering"
   },
   {
     "id": 2,
-    "frequency": "Twice per month",
-    "anchor_pay_date": "2018-09-01",
-    "day_1": 1,
-    "day_2": 15,
-    "name": "Salaried"
+    "frequency": "Monthly",
+    "anchor_pay_date": "2020-05-31",
+    "day_1": 31,
+    "day_2": null,
+    "name": "Sales"
+  },
+  {
+    "id": 3,
+    "frequency": "Monthly",
+    "anchor_pay_date": "2020-05-31",
+    "day_1": 31,
+    "day_2": null,
+    "name": "Staff"
   }
 ]
 ```

--- a/_posts/2018-04-24-pay_schedules.markdown
+++ b/_posts/2018-04-24-pay_schedules.markdown
@@ -18,7 +18,7 @@ when they should be paid. A company can have multiple pay schedules.
 | `anchor_pay_date`                 | String           |     X     |          |         | The first date that employees on this pay schedule are paid with Gusto
 | `day_1`                      | Integer           |     X     |     X    |         | An integer between 1 and 31 indicating the first day of the month that employees are paid. This field is only relevant for pay schedules with the "Twice per month" and "Monthly" frequencies. It will be null for pay schedules with other frequencies.
 | `day_2`                      | Integer           |     X     |     X    |         | An integer between 1 and 31 indicating the second day of the month that employees are paid. This field is the second pay date for pay schedules with the "Twice per month" frequency. It will be null for pay schedules with other frequencies.
-| `name`                      | String           |     X     |     X     |         | A name describing the pay group, for example, "Hourly" when all hourly employees are assigned to it, or the name of the department if the pay schedule is for an entire department. The name of the schedule is dependent on how a company decides to group employees into pay schedules and should not be used programmatically to make any assumptions.
+| `name`                      | String           |     X     |     X     |         | A name describing the pay schedule group. The name of the schedule is dependent on how a company groups their employees into pay schedules. For example, Hourly for all hourly employees or a department name if the pay schedule is for an entire department. This name should not be used programmatically to make any assumptions.
 
 ## Get a pay schedule
 

--- a/_posts/2018-04-24-pay_schedules.markdown
+++ b/_posts/2018-04-24-pay_schedules.markdown
@@ -33,11 +33,11 @@ when they should be paid. A company can have multiple pay schedules.
 ```json
 {
   "id": 1,
-  "frequency": "Every other week",
-  "anchor_pay_date": "2018-01-12",
-  "day_1": null,
-  "day_2": null,
-  "name": "Hourly"
+  "frequency": "Twice per month",
+  "anchor_pay_date": "2020-05-15",
+  "day_1": 15,
+  "day_2": 31,
+  "name": "Engineering"
 }
 ```
 


### PR DESCRIPTION
The purpose of these documentation changes is to emphasize the possibility of having more than two pay schedules.
While our docs do imply a company can have many pay schedules, we've only supported hourly/salaried (up to 2), so it's possible that api partners have built these assumptions into their code. This documentation change includes an example with 3 pay schedules and emphasizes that `name` is not an attribute they should enumerate.

![image](https://user-images.githubusercontent.com/653256/97890228-4aaaab00-1cfb-11eb-8aab-c5453ac13e76.png)

![image](https://user-images.githubusercontent.com/653256/97890381-7a59b300-1cfb-11eb-95d5-f87763b5fe75.png)
